### PR TITLE
Add link to Hyperbeam

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Coming here for the first time, or don't know what remote browser isolation is?
 
 ## Some other products that this is similar to:
 
+- [Hyperbeam](https://hyperbeam.com) embeddable multiplayer browsers and apps
 - CloudFlare remote browsers (formerly S2)
 - Menlo Security Web and Browser isolation platform
-- Hyperbeam embeddable multiplayer browsers and apps
 - McAfee browser isolation (formerly Light Point)
 - Ericom browser isolation
 - Zscaler zero trust web browsing 


### PR DESCRIPTION
Hey Cris, just a heads up we have a really popular watch party website called "Hyperbeam Watch Party" with a similar URL (https://watch.hyperbeam.com).

I'm worried people will Google "Hyperbeam" and possibly end up on a watch party website, causing confusion for everyone. Would appreciate you merging this MR.

Thanks,

Philip