### PR TITLE
solidified select input

### DIFF
--- a/src/public/bundle_image_start.js
+++ b/src/public/bundle_image_start.js
@@ -5,7 +5,8 @@
     let {
       selectInput: {
         selectOpen,
-        values
+        values,
+        selected
       },
       executionContextId
     } = _ref;
@@ -13,19 +14,22 @@
     if (state.ignoreSelectInputEvents) return;
     toggleSelect({
       selectOpen,
-      values
+      values,
+      selected
     });
   }
 
   function toggleSelect(_ref2) {
     let {
       selectOpen,
-      values
+      values,
+      selected
     } = _ref2;
     const input = document.querySelector('#selectinput');
 
     if (selectOpen) {
       input.innerHTML = values;
+      input.selectedIndex = selected;
       input.classList.add('open'); //input.focus();
     } else {
       input.classList.remove('open');

--- a/src/public/voodoo/src/handlers/selectInput.js
+++ b/src/public/voodoo/src/handlers/selectInput.js
@@ -1,13 +1,14 @@
-export function handleSelectMessage({selectInput:{selectOpen, values}, executionContextId}, state) {
+export function handleSelectMessage({selectInput:{selectOpen, values, selected}, executionContextId}, state) {
   state.waitingExecutionContext = executionContextId;
   if ( state.ignoreSelectInputEvents ) return;
-  toggleSelect({selectOpen,values});
+  toggleSelect({selectOpen,values, selected});
 }
 
-function toggleSelect({selectOpen, values}) {
+function toggleSelect({selectOpen, values, selected}) {
   const input = document.querySelector('#selectinput');
   if ( selectOpen ) {
     input.innerHTML = values;
+    input.selectedIndex = selected;
     input.classList.add('open');
     //input.focus();
   } else {


### PR DESCRIPTION
1. there was a theoretical security issue where an attack could do remote-local xss by crafting a select input with an options element that contained a script, or local tracking, with an options element that contained an imag (or other network load) to a resource monitored by the attacked. while modern browsers tested (chrome) did not execute this script, or network load, this patch is to prevent the theoretical vuln as well as any potential exploits that have not been considered. now instead of sending the innerHTML of the select control to be filled on the client, we simply construct synthetic options elements comprising the value of the remote option and any innerText and transmit that over the wire.
2. previously we did not consider selectedIndex to indicate the default currently selected option. now we do, bringing the experience more into line with using the page locally, even when it's remote.